### PR TITLE
feat: add Liquid Ether background effect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import LiquidEtherClient from "@/components/liquid-ether-client";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -10,6 +11,7 @@ const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
+    <LiquidEtherClient />
     <TooltipProvider>
       <Toaster />
       <Sonner />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ export const Header = () => {
       transition={{ duration: 0.6, ease: "easeOut" }}
       className="fixed top-0 left-0 right-0 z-50 p-4"
     >
-      <div className="max-w-6xl mx-auto flex justify-between items-center">
+      <div className="max-w-6xl mx-auto flex justify-between items-center rounded-2xl bg-background/70 backdrop-blur-md border border-border/40 px-4 py-3 shadow-[0_0_30px_rgba(124,58,237,0.15)]">
         <motion.div
           initial={{ x: -30, opacity: 0 }}
           animate={{ x: 0, opacity: 1 }}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -115,44 +115,51 @@ export const HeroSection = () => {
           <span className="text-muted-foreground">The heart of our infrastructure</span>
         </motion.div>
 
-        <motion.h1
-          initial={{ y: 50, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ 
-            duration: 0.8,
-            ease: "easeOut",
-            delay: 0.4
-          }}
-          className="text-6xl md:text-8xl font-bold mb-6 gradient-text"
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.8, ease: "easeOut", delay: 0.3 }}
+          className="mx-auto mb-12 max-w-5xl rounded-3xl border border-border/40 bg-background/75 px-6 py-8 backdrop-blur-lg shadow-[0_0_60px_rgba(124,58,237,0.2)]"
         >
-          {t('heroTitle')}
-        </motion.h1>
+          <motion.h1
+            initial={{ y: 50, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{
+              duration: 0.8,
+              ease: "easeOut",
+              delay: 0.4
+            }}
+            className="text-6xl md:text-8xl font-bold mb-6 gradient-text"
+          >
+            {t('heroTitle')}
+          </motion.h1>
 
-        <motion.p
-          initial={{ y: 30, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ 
-            duration: 0.6,
-            ease: "easeOut",
-            delay: 0.6
-          }}
-          className="text-xl md:text-2xl text-muted-foreground mb-4 max-w-3xl mx-auto leading-relaxed"
-        >
-          {t('heroSubtitle')}
-        </motion.p>
+          <motion.p
+            initial={{ y: 30, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{
+              duration: 0.6,
+              ease: "easeOut",
+              delay: 0.6
+            }}
+            className="text-xl md:text-2xl text-muted-foreground mb-4 max-w-3xl mx-auto leading-relaxed"
+          >
+            {t('heroSubtitle')}
+          </motion.p>
 
-        <motion.p
-          initial={{ y: 20, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ 
-            duration: 0.6,
-            ease: "easeOut",
-            delay: 0.8
-          }}
-          className="text-lg text-muted-foreground/80 mb-12 max-w-2xl mx-auto"
-        >
-          {t('heroDescription')}
-        </motion.p>
+          <motion.p
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{
+              duration: 0.6,
+              ease: "easeOut",
+              delay: 0.8
+            }}
+            className="text-lg text-muted-foreground/80 max-w-2xl mx-auto"
+          >
+            {t('heroDescription')}
+          </motion.p>
+        </motion.div>
 
         <motion.div
           initial={{ y: 20, opacity: 0 }}

--- a/src/components/liquid-ether-client.tsx
+++ b/src/components/liquid-ether-client.tsx
@@ -1,0 +1,221 @@
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+
+import { LIQUID_ETHER_DEFAULT_COLORS, getLiquidEtherDefaultPalette } from "@/lib/liquid-ether-defaults";
+import type { LiquidEtherProps } from "./liquid-ether";
+
+const LiquidEtherCanvas = lazy(() => import("./liquid-ether"));
+
+const STATIC_LAYER_OPACITY = 0.85;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const getEnvValue = (keys: string[]) => {
+  const env = import.meta.env as Record<string, string | undefined>;
+  for (const key of keys) {
+    const value = env[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const parseBoolean = (value: string | undefined, fallback: boolean) => {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "y"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no", "n"].includes(normalized)) {
+    return false;
+  }
+  return fallback;
+};
+
+const parseNumber = (value: string | undefined, fallback: number, min?: number, max?: number) => {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) {
+    return fallback;
+  }
+  if (typeof min === "number" && parsed < min) {
+    return min;
+  }
+  if (typeof max === "number" && parsed > max) {
+    return max;
+  }
+  return parsed;
+};
+
+const hexToRgba = (hex: string, alpha: number) => {
+  const sanitized = hex.replace("#", "");
+  const normalized =
+    sanitized.length === 3
+      ? sanitized
+          .split("")
+          .map((value) => value + value)
+          .join("")
+      : sanitized.padEnd(6, "0");
+  const intValue = Number.parseInt(normalized.slice(0, 6), 16);
+  const r = (intValue >> 16) & 255;
+  const g = (intValue >> 8) & 255;
+  const b = intValue & 255;
+  return `rgba(${r}, ${g}, ${b}, ${clamp(alpha, 0, 1)})`;
+};
+
+const parseColors = (value?: string) => {
+  if (!value) {
+    return getLiquidEtherDefaultPalette();
+  }
+  const palette = value
+    .split(",")
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+  if (palette.length === 0) {
+    return getLiquidEtherDefaultPalette();
+  }
+  return palette;
+};
+
+const usePrefersReducedMotion = () => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    setPrefersReducedMotion(query.matches);
+    query.addEventListener("change", handleChange);
+
+    return () => {
+      query.removeEventListener("change", handleChange);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+};
+
+const useIsMounted = () => {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return isMounted;
+};
+
+const useWebglSupport = (shouldCheck: boolean) => {
+  const [isSupported, setIsSupported] = useState(false);
+
+  useEffect(() => {
+    if (!shouldCheck) {
+      setIsSupported(false);
+      return;
+    }
+
+    let supported = false;
+    try {
+      const canvas = document.createElement("canvas");
+      supported = Boolean(canvas.getContext("webgl") || canvas.getContext("experimental-webgl"));
+    } catch (error) {
+      supported = false;
+    }
+
+    setIsSupported(supported);
+  }, [shouldCheck]);
+
+  return isSupported;
+};
+
+const createStaticGradient = (colors: string[]) => {
+  const layers = [
+    `radial-gradient(circle at 20% 20%, ${hexToRgba(colors[0] ?? LIQUID_ETHER_DEFAULT_COLORS[0], STATIC_LAYER_OPACITY)}, transparent 65%)`,
+    `radial-gradient(circle at 80% 25%, ${hexToRgba(colors[1] ?? LIQUID_ETHER_DEFAULT_COLORS[1], STATIC_LAYER_OPACITY)}, transparent 60%)`,
+    `radial-gradient(circle at 50% 80%, ${hexToRgba(colors[2] ?? LIQUID_ETHER_DEFAULT_COLORS[2], STATIC_LAYER_OPACITY)}, transparent 70%)`,
+    `linear-gradient(135deg, ${hexToRgba(colors[0] ?? LIQUID_ETHER_DEFAULT_COLORS[0], 0.55)}, ${hexToRgba(colors[1] ?? LIQUID_ETHER_DEFAULT_COLORS[1], 0.35)}, ${hexToRgba(colors[2] ?? LIQUID_ETHER_DEFAULT_COLORS[2], 0.45)})`,
+  ];
+  return layers.join(", ");
+};
+
+const LiquidEtherStatic = ({ colors }: { colors: string[] }) => (
+  <div
+    aria-hidden
+    className="h-full w-full"
+    style={{
+      background: createStaticGradient(colors),
+      filter: "blur(0px)",
+      transform: "translateZ(0)",
+    }}
+  />
+);
+
+const LiquidEtherClient = () => {
+  const enabled = parseBoolean(
+    getEnvValue(["NEXT_PUBLIC_LIQUIDETHER_ENABLED", "VITE_LIQUIDETHER_ENABLED"]),
+    true
+  );
+  const colors = useMemo(() => {
+    return parseColors(getEnvValue(["NEXT_PUBLIC_LIQUIDETHER_COLORS", "VITE_LIQUIDETHER_COLORS"]));
+  }, []);
+  const resolution = parseNumber(
+    getEnvValue(["NEXT_PUBLIC_LIQUIDETHER_RESOLUTION", "VITE_LIQUIDETHER_RESOLUTION"]),
+    0.5,
+    0.3,
+    0.6
+  );
+  const intensity = parseNumber(
+    getEnvValue(["NEXT_PUBLIC_LIQUIDETHER_INTENSITY", "VITE_LIQUIDETHER_INTENSITY"]),
+    2.2
+  );
+
+  const isMounted = useIsMounted();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const canUseFluid = useWebglSupport(enabled && isMounted && !prefersReducedMotion);
+
+  if (!enabled) {
+    return null;
+  }
+
+  const fallback = <LiquidEtherStatic colors={colors} />;
+  const baseProps: LiquidEtherProps = {
+    colors,
+    resolution,
+    autoIntensity: intensity,
+    mouseForce: 20,
+    cursorSize: 100,
+    iterationsViscous: 32,
+    iterationsPoisson: 32,
+    isViscous: false,
+    autoDemo: true,
+    autoSpeed: 0.5,
+    takeoverDuration: 0.25,
+    autoResumeDelay: 3000,
+    autoRampDuration: 0.6,
+    isBounce: false,
+  };
+
+  return (
+    <div className="fixed inset-0 -z-10 pointer-events-none" aria-hidden>
+      {!isMounted || prefersReducedMotion || !canUseFluid ? (
+        fallback
+      ) : (
+        <Suspense fallback={fallback}>
+          <LiquidEtherCanvas {...baseProps} />
+        </Suspense>
+      )}
+    </div>
+  );
+};
+
+export default LiquidEtherClient;

--- a/src/components/liquid-ether.tsx
+++ b/src/components/liquid-ether.tsx
@@ -1,0 +1,275 @@
+import { memo, useEffect, useRef } from "react";
+
+import { getLiquidEtherDefaultPalette } from "@/lib/liquid-ether-defaults";
+import { cn } from "@/lib/utils";
+
+export interface LiquidEtherProps {
+  colors?: string[];
+  mouseForce?: number;
+  cursorSize?: number;
+  isViscous?: boolean;
+  viscous?: number;
+  iterationsViscous?: number;
+  iterationsPoisson?: number;
+  resolution?: number;
+  isBounce?: boolean;
+  autoDemo?: boolean;
+  autoSpeed?: number;
+  autoIntensity?: number;
+  takeoverDuration?: number;
+  autoResumeDelay?: number;
+  autoRampDuration?: number;
+  className?: string;
+}
+
+interface PointerState {
+  x: number;
+  y: number;
+  targetX: number;
+  targetY: number;
+  lastInputTime: number;
+  autoActive: boolean;
+  autoStartTime: number;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const hexToRgba = (hex: string, alpha: number) => {
+  const sanitized = hex.replace("#", "");
+  const normalized =
+    sanitized.length === 3
+      ? sanitized
+          .split("")
+          .map((value) => value + value)
+          .join("")
+      : sanitized.padEnd(6, "0");
+  const intValue = parseInt(normalized.slice(0, 6), 16);
+  const r = (intValue >> 16) & 255;
+  const g = (intValue >> 8) & 255;
+  const b = intValue & 255;
+  const clampedAlpha = clamp(alpha, 0, 1);
+
+  return `rgba(${r}, ${g}, ${b}, ${clampedAlpha})`;
+};
+
+const DEFAULT_COLORS = getLiquidEtherDefaultPalette();
+
+const getGradientStops = (colors: string[]) => {
+  const slices = colors.length;
+  return colors.map((color, index) => ({
+    angle: (index / Math.max(1, slices)) * Math.PI * 2,
+    color,
+  }));
+};
+
+const LiquidEther = memo(
+  ({
+    colors = DEFAULT_COLORS,
+    mouseForce = 20,
+    cursorSize = 100,
+    isViscous = false,
+    viscous = 30,
+    iterationsViscous = 32,
+    iterationsPoisson = 32,
+    resolution = 0.5,
+    isBounce = false,
+    autoDemo = true,
+    autoSpeed = 0.5,
+    autoIntensity = 2.2,
+    takeoverDuration = 0.25,
+    autoResumeDelay = 3000,
+    autoRampDuration = 0.6,
+    className,
+  }: LiquidEtherProps) => {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const animationRef = useRef<number>();
+    const pointerRef = useRef<PointerState>({
+      x: 0,
+      y: 0,
+      targetX: 0,
+      targetY: 0,
+      lastInputTime: 0,
+      autoActive: autoDemo,
+      autoStartTime: performance.now(),
+    });
+    const sizeRef = useRef({ width: 0, height: 0 });
+
+    useEffect(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        return;
+      }
+
+      const ctx = canvas.getContext("2d", { alpha: true });
+      if (!ctx) {
+        return;
+      }
+
+      const dpr = window.devicePixelRatio || 1;
+      const normalizedResolution = clamp(resolution, 0.3, 0.6);
+      const smoothingStrength = clamp(mouseForce / 120, 0.04, 0.25);
+      const viscosityFactor = isViscous ? clamp(viscous / 50, 0.2, 1.5) : clamp(iterationsViscous / 48, 0.4, 1.2);
+      const poissonFactor = clamp(iterationsPoisson / 48, 0.2, 1.4);
+
+      const pointer = pointerRef.current;
+      const gradients = getGradientStops(colors.length ? colors : DEFAULT_COLORS);
+
+      const updateSize = () => {
+        const { clientWidth, clientHeight } = canvas;
+        const width = Math.max(1, clientWidth);
+        const height = Math.max(1, clientHeight);
+        sizeRef.current = { width, height };
+        const scaledWidth = Math.floor(width * normalizedResolution * dpr);
+        const scaledHeight = Math.floor(height * normalizedResolution * dpr);
+        if (pointer.x === 0 && pointer.y === 0) {
+          pointer.x = width / 2;
+          pointer.y = height / 2;
+          pointer.targetX = width / 2;
+          pointer.targetY = height / 2;
+        }
+
+        if (canvas.width !== scaledWidth || canvas.height !== scaledHeight) {
+          canvas.width = scaledWidth;
+          canvas.height = scaledHeight;
+          ctx.setTransform(1, 0, 0, 1, 0, 0);
+          ctx.scale((scaledWidth / width) * poissonFactor, (scaledHeight / height) * poissonFactor);
+        }
+      };
+
+      updateSize();
+
+      let resizeObserver: ResizeObserver | null = null;
+      if (typeof ResizeObserver !== "undefined") {
+        resizeObserver = new ResizeObserver(updateSize);
+        resizeObserver.observe(canvas);
+      }
+
+      const handlePointerMove = (event: PointerEvent) => {
+        const rect = canvas.getBoundingClientRect();
+        pointer.targetX = event.clientX - rect.left;
+        pointer.targetY = event.clientY - rect.top;
+        pointer.lastInputTime = performance.now();
+        pointer.autoActive = false;
+      };
+
+      const handlePointerLeave = () => {
+        pointer.lastInputTime = performance.now();
+      };
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerleave", handlePointerLeave);
+
+      let lastTimestamp = performance.now();
+      const rampDurationMs = autoRampDuration * 1000;
+      const takeoverDurationMs = takeoverDuration * 1000;
+
+      const render = (timestamp: number) => {
+        const { width, height } = sizeRef.current;
+        if (width === 0 || height === 0) {
+          animationRef.current = requestAnimationFrame(render);
+          return;
+        }
+
+        const delta = timestamp - lastTimestamp;
+        lastTimestamp = timestamp;
+
+        const timeSinceInput = timestamp - pointer.lastInputTime;
+        if (autoDemo && timeSinceInput > autoResumeDelay) {
+          if (!pointer.autoActive) {
+            pointer.autoActive = true;
+            pointer.autoStartTime = timestamp;
+          }
+        }
+
+        if (pointer.autoActive && autoDemo) {
+          const elapsed = timestamp - pointer.autoStartTime;
+          const ramp = clamp(elapsed / Math.max(1, rampDurationMs), 0, 1);
+          const autoTime = timestamp * autoSpeed * 0.001;
+          const amplitude = Math.min(width, height) * 0.25 * autoIntensity * ramp;
+          pointer.targetX = width / 2 + Math.cos(autoTime * 0.9) * amplitude;
+          pointer.targetY = height / 2 + Math.sin(autoTime * 1.1) * amplitude;
+        }
+
+        const easingFactor = smoothingStrength * clamp(delta / 16.67, 0.5, 1.5);
+        pointer.x += (pointer.targetX - pointer.x) * easingFactor * viscosityFactor;
+        pointer.y += (pointer.targetY - pointer.y) * easingFactor * viscosityFactor;
+
+        if (!pointer.autoActive && timeSinceInput < takeoverDurationMs) {
+          const takeoverT = clamp(timeSinceInput / Math.max(1, takeoverDurationMs), 0, 1);
+          pointer.x = pointer.x + (pointer.targetX - pointer.x) * takeoverT;
+          pointer.y = pointer.y + (pointer.targetY - pointer.y) * takeoverT;
+        }
+
+        if (isBounce) {
+          pointer.x = clamp(pointer.x, cursorSize * 0.5, width - cursorSize * 0.5);
+          pointer.y = clamp(pointer.y, cursorSize * 0.5, height - cursorSize * 0.5);
+        }
+
+        ctx.globalCompositeOperation = "source-over";
+        ctx.clearRect(0, 0, width, height);
+        const radius = Math.max(width, height) * 0.65 + cursorSize;
+        const tailAlpha = clamp(0.08 * viscosityFactor, 0.04, 0.18);
+        ctx.fillStyle = hexToRgba("#050017", tailAlpha);
+        ctx.fillRect(0, 0, width, height);
+
+        gradients.forEach(({ angle, color }, index) => {
+          const wobble = timestamp * 0.0003 * (index + 1);
+          const offsetRadius = cursorSize * (1 + Math.sin(wobble) * 0.4);
+          const offsetX = Math.cos(angle + wobble) * offsetRadius;
+          const offsetY = Math.sin(angle - wobble) * offsetRadius;
+          const gradient = ctx.createRadialGradient(
+            pointer.x + offsetX,
+            pointer.y + offsetY,
+            cursorSize * 0.15,
+            pointer.x + offsetX,
+            pointer.y + offsetY,
+            radius
+          );
+          gradient.addColorStop(0, hexToRgba(color, 0.9));
+          gradient.addColorStop(0.25, hexToRgba(color, 0.45));
+          gradient.addColorStop(1, hexToRgba(color, 0));
+          ctx.globalAlpha = clamp(0.9 / gradients.length, 0.18, 0.6);
+          ctx.fillStyle = gradient;
+          ctx.fillRect(0, 0, width, height);
+        });
+
+        ctx.globalAlpha = 1;
+
+        animationRef.current = requestAnimationFrame(render);
+      };
+
+      animationRef.current = requestAnimationFrame(render);
+
+      return () => {
+        resizeObserver?.disconnect();
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerleave", handlePointerLeave);
+        if (animationRef.current) {
+          cancelAnimationFrame(animationRef.current);
+        }
+      };
+    }, [
+      autoDemo,
+      autoIntensity,
+      autoRampDuration,
+      autoResumeDelay,
+      autoSpeed,
+      colors,
+      cursorSize,
+      isBounce,
+      isViscous,
+      iterationsPoisson,
+      iterationsViscous,
+      mouseForce,
+      resolution,
+      takeoverDuration,
+      viscous,
+    ]);
+
+    return <canvas ref={canvasRef} className={cn("h-full w-full", className)} aria-hidden />;
+  }
+);
+
+LiquidEther.displayName = "LiquidEther";
+
+export default LiquidEther;

--- a/src/lib/liquid-ether-defaults.ts
+++ b/src/lib/liquid-ether-defaults.ts
@@ -1,0 +1,3 @@
+export const LIQUID_ETHER_DEFAULT_COLORS = ["#7C3AED", "#0EA5E9", "#EC4899"] as const;
+
+export const getLiquidEtherDefaultPalette = () => [...LIQUID_ETHER_DEFAULT_COLORS];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,9 +7,9 @@ import { Footer } from "@/components/Footer";
 
 const Index = () => {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen relative">
       <Header />
-      <main>
+      <main className="relative z-10">
         <HeroSection />
         <WhatIsSection />
         <EcosystemSection />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -12,11 +12,13 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+    <div className="min-h-screen flex items-center justify-center p-6 relative">
+      <div className="relative z-10 max-w-md w-full text-center space-y-4 rounded-3xl border border-border/40 bg-background/80 backdrop-blur-lg px-8 py-10 shadow-[0_0_40px_rgba(14,165,233,0.25)]">
+        <h1 className="text-5xl font-bold gradient-text">404</h1>
+        <p className="text-lg text-muted-foreground">
+          Oops! Page not found
+        </p>
+        <a href="/" className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-primary-foreground transition-transform hover:scale-105">
           Return to Home
         </a>
       </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly NEXT_PUBLIC_LIQUIDETHER_ENABLED?: string;
+  readonly NEXT_PUBLIC_LIQUIDETHER_RESOLUTION?: string;
+  readonly NEXT_PUBLIC_LIQUIDETHER_INTENSITY?: string;
+  readonly NEXT_PUBLIC_LIQUIDETHER_COLORS?: string;
+  readonly VITE_LIQUIDETHER_ENABLED?: string;
+  readonly VITE_LIQUIDETHER_RESOLUTION?: string;
+  readonly VITE_LIQUIDETHER_INTENSITY?: string;
+  readonly VITE_LIQUIDETHER_COLORS?: string;
+}


### PR DESCRIPTION
## Summary
- add a canvas-based Liquid Ether background with configurable physics defaults and graceful cleanup
- load the effect from a client-only wrapper that reads env overrides, respects reduced motion, and falls back to a static gradient
- adjust layout surfaces (app shell, hero, header, 404) so the animated background remains visible while preserving readability

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98b27d014832283af8ea69d65de0d