### PR TITLE
feat: add Liquid Ether background system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { LiquidEtherClient } from "@/components/liquid-ether/LiquidEtherClient";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
@@ -11,6 +12,7 @@ const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
+      <LiquidEtherClient />
       <Toaster />
       <Sonner />
       <BrowserRouter>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,9 +8,9 @@ export const Header = () => {
       initial={{ y: -50, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
-      className="fixed top-0 left-0 right-0 z-50 p-4"
+      className="fixed top-0 left-0 right-0 z-40 p-4"
     >
-      <div className="max-w-6xl mx-auto flex justify-between items-center">
+      <div className="max-w-6xl mx-auto flex items-center justify-between rounded-2xl border border-white/10 bg-background/70 px-5 py-3 shadow-[0_20px_45px_rgba(16,18,35,0.35)] backdrop-blur-md">
         <motion.div
           initial={{ x: -30, opacity: 0 }}
           animate={{ x: 0, opacity: 1 }}

--- a/src/components/liquid-ether/LiquidEther.tsx
+++ b/src/components/liquid-ether/LiquidEther.tsx
@@ -1,0 +1,378 @@
+import { useEffect, useRef } from "react";
+import type { LiquidEtherProps } from "@/lib/liquid-ether";
+import { defaultLiquidEtherColors } from "@/lib/liquid-ether";
+
+interface BlobState {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  baseRadius: number;
+  radius: number;
+  color: string;
+  offset: number;
+  noise: number;
+}
+
+interface PointerState {
+  x: number;
+  y: number;
+  strength: number;
+  targetStrength: number;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const createColorParser = () => {
+  const fallback: [number, number, number] = [124, 58, 237];
+  const rgbCache = new Map<string, [number, number, number]>();
+  const rgbaCache = new Map<string, string>();
+
+  const parse = (color: string): [number, number, number] => {
+    const key = color.trim();
+    const cached = rgbCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    let rgb = fallback;
+    const hexMatch = key.match(/^#([0-9a-f]{3,8})$/i);
+    if (hexMatch) {
+      const hex = hexMatch[1];
+      const normalized =
+        hex.length === 3
+          ? hex
+              .split("")
+              .map((value) => value + value)
+              .join("")
+          : hex.length >= 6
+          ? hex.slice(0, 6)
+          : hex.padEnd(6, "0");
+      const r = parseInt(normalized.slice(0, 2), 16);
+      const g = parseInt(normalized.slice(2, 4), 16);
+      const b = parseInt(normalized.slice(4, 6), 16);
+      rgb = [r, g, b];
+    } else {
+      const rgbMatch = key.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+      if (rgbMatch) {
+        rgb = [
+          Number.parseInt(rgbMatch[1], 10),
+          Number.parseInt(rgbMatch[2], 10),
+          Number.parseInt(rgbMatch[3], 10),
+        ];
+      }
+    }
+
+    rgbCache.set(key, rgb);
+    return rgb;
+  };
+
+  return (color: string, alpha: number) => {
+    const cacheKey = `${color}|${alpha}`;
+    const cached = rgbaCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const [r, g, b] = parse(color);
+    const rgba = `rgba(${r}, ${g}, ${b}, ${clamp(alpha, 0, 1)})`;
+    rgbaCache.set(cacheKey, rgba);
+    return rgba;
+  };
+};
+
+const createBlobs = (
+  width: number,
+  height: number,
+  colors: string[],
+  autoIntensity: number
+) => {
+  const maxDimension = Math.max(width, height);
+  const count = Math.max(8, colors.length * 4);
+
+  return Array.from({ length: count }, (_, index): BlobState => {
+    const color = colors[index % colors.length];
+    const baseRadius =
+      maxDimension * (0.24 + (index % colors.length) * 0.015 + Math.random() * 0.08);
+
+    return {
+      x: Math.random() * width,
+      y: Math.random() * height,
+      vx: 0,
+      vy: 0,
+      baseRadius,
+      radius: baseRadius,
+      color,
+      offset: Math.random() * Math.PI * 2,
+      noise: 0.5 + Math.random() * 0.6 * autoIntensity,
+    };
+  });
+};
+
+const LiquidEther = ({
+  colors,
+  resolution,
+  mouseForce,
+  cursorSize,
+  isViscous,
+  viscous,
+  iterationsViscous,
+  iterationsPoisson,
+  isBounce,
+  autoDemo,
+  autoSpeed,
+  autoIntensity,
+  takeoverDuration,
+  autoResumeDelay,
+  autoRampDuration,
+}: LiquidEtherProps) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const context = canvas.getContext("2d", { alpha: true });
+    if (!context) return;
+
+    const palette = colors.length > 0 ? colors : [...defaultLiquidEtherColors];
+    const pointer: PointerState = {
+      x: window.innerWidth / 2,
+      y: window.innerHeight / 2,
+      strength: 0,
+      targetStrength: 0,
+    };
+
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+    let scale = 1;
+    let frame = 0;
+    let blobs = createBlobs(width, height, palette, autoIntensity);
+    let lastInteraction = performance.now();
+    let lastTime = performance.now();
+    const autoDelayMs = Math.max(0, autoResumeDelay);
+    const takeoverSeconds = Math.max(takeoverDuration, 0.05);
+    const fadeSeconds = Math.max(autoRampDuration, 0.1);
+    const swirlFactor = Math.max(1, iterationsPoisson) / 28;
+    const smoothingFactor = Math.max(1, iterationsViscous) / 64;
+    const colorToRgba = createColorParser();
+
+    const updateCanvasSize = () => {
+      width = window.innerWidth;
+      height = window.innerHeight;
+      pointer.x = clamp(pointer.x, 0, width);
+      pointer.y = clamp(pointer.y, 0, height);
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      scale = dpr * clamp(resolution, 0.3, 0.6);
+      canvas.width = Math.max(1, Math.floor(width * scale));
+      canvas.height = Math.max(1, Math.floor(height * scale));
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      context.setTransform(scale, 0, 0, scale, 0, 0);
+    };
+
+    updateCanvasSize();
+
+    const handleResize = () => {
+      updateCanvasSize();
+      blobs = createBlobs(width, height, palette, autoIntensity);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      pointer.x = clamp(event.clientX, 0, width);
+      pointer.y = clamp(event.clientY, 0, height);
+      pointer.targetStrength = 1;
+      lastInteraction = performance.now();
+    };
+
+    const handlePointerUp = () => {
+      pointer.targetStrength = 0;
+      lastInteraction = performance.now();
+    };
+
+    const handleBlur = () => {
+      pointer.targetStrength = 0;
+      pointer.strength = 0;
+    };
+
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("pointermove", handlePointerMove, { passive: true });
+    window.addEventListener("pointerdown", handlePointerMove, { passive: true });
+    window.addEventListener("pointerup", handlePointerUp, { passive: true });
+    window.addEventListener("pointercancel", handlePointerUp, { passive: true });
+    window.addEventListener("blur", handleBlur);
+
+    const autoState = {
+      angle: Math.random() * Math.PI * 2,
+    };
+
+    const renderFrame = (time: number) => {
+      frame = window.requestAnimationFrame(renderFrame);
+
+      const delta = clamp((time - lastTime) / 1000, 0, 0.08);
+      const timeSeconds = time / 1000;
+      lastTime = time;
+
+      const timeSinceInteraction = time - lastInteraction;
+      if (autoDemo && timeSinceInteraction > autoDelayMs) {
+        autoState.angle += delta * autoSpeed * Math.PI * 2;
+        const radius = Math.min(width, height) * 0.25 * autoIntensity;
+        const targetX = width / 2 + Math.cos(autoState.angle) * radius;
+        const targetY = height / 2 + Math.sin(autoState.angle) * radius;
+        const lerp = 1 - Math.exp(-delta / takeoverSeconds);
+        pointer.x += (targetX - pointer.x) * lerp;
+        pointer.y += (targetY - pointer.y) * lerp;
+        const rampProgress = clamp(
+          (timeSinceInteraction - autoDelayMs) / (autoRampDuration * 1000),
+          0,
+          1
+        );
+        pointer.targetStrength = Math.max(pointer.targetStrength, rampProgress);
+      }
+
+      const fadeRate = pointer.targetStrength > pointer.strength ? takeoverSeconds : fadeSeconds;
+      const strengthStep = delta / fadeRate;
+      if (pointer.targetStrength > pointer.strength) {
+        pointer.strength = clamp(pointer.strength + strengthStep, 0, 1);
+      } else {
+        pointer.strength = clamp(pointer.strength - strengthStep, 0, 1);
+      }
+
+      pointer.x = clamp(pointer.x, 0, width);
+      pointer.y = clamp(pointer.y, 0, height);
+
+      const damping = Math.exp(-delta * (isViscous ? viscous / 8 : 3.4));
+      const pointerRadius = Math.max(cursorSize, 40);
+      const pointerForce = mouseForce;
+
+      blobs.forEach((blob, index) => {
+        const dx = pointer.x - blob.x;
+        const dy = pointer.y - blob.y;
+        const distSq = dx * dx + dy * dy + 1e-6;
+        const dist = Math.sqrt(distSq);
+        const normalizedX = dx / dist;
+        const normalizedY = dy / dist;
+        const gaussian = Math.exp(-(distSq) / (2 * pointerRadius * pointerRadius));
+        const attraction = pointer.strength * pointerForce * gaussian;
+
+        blob.vx += normalizedX * attraction * delta * 20;
+        blob.vy += normalizedY * attraction * delta * 20;
+
+        const swirlAngle = Math.atan2(dy, dx) + Math.PI / 2;
+        const swirlStrength = swirlFactor * pointer.strength * gaussian * autoIntensity;
+        blob.vx += Math.cos(swirlAngle) * swirlStrength * 18 * delta;
+        blob.vy += Math.sin(swirlAngle) * swirlStrength * 18 * delta;
+
+        const noisePhase = timeSeconds * (0.6 + index * 0.03) + blob.offset;
+        blob.vx += Math.cos(noisePhase) * blob.noise * autoIntensity * delta * 15;
+        blob.vy += Math.sin(noisePhase * 0.8) * blob.noise * autoIntensity * delta * 15;
+
+        blob.vx *= damping;
+        blob.vy *= damping;
+
+        blob.x += blob.vx;
+        blob.y += blob.vy;
+
+        if (isBounce) {
+          if (blob.x < 0) {
+            blob.x = 0;
+            blob.vx *= -0.6;
+          } else if (blob.x > width) {
+            blob.x = width;
+            blob.vx *= -0.6;
+          }
+          if (blob.y < 0) {
+            blob.y = 0;
+            blob.vy *= -0.6;
+          } else if (blob.y > height) {
+            blob.y = height;
+            blob.vy *= -0.6;
+          }
+        } else {
+          const wrapRadius = blob.baseRadius;
+          if (blob.x < -wrapRadius) blob.x = width + wrapRadius;
+          if (blob.x > width + wrapRadius) blob.x = -wrapRadius;
+          if (blob.y < -wrapRadius) blob.y = height + wrapRadius;
+          if (blob.y > height + wrapRadius) blob.y = -wrapRadius;
+        }
+
+        const breathing = 1 + Math.sin(timeSeconds * 0.7 + blob.offset) * 0.12 * smoothingFactor;
+        blob.radius = clamp(
+          blob.baseRadius * breathing,
+          blob.baseRadius * 0.65,
+          blob.baseRadius * 1.35
+        );
+      });
+
+      context.setTransform(scale, 0, 0, scale, 0, 0);
+      context.globalCompositeOperation = "source-over";
+      context.fillStyle = "rgba(6, 9, 20, 0.22)";
+      context.fillRect(0, 0, width, height);
+
+      context.globalCompositeOperation = "lighter";
+      blobs.forEach((blob) => {
+        const gradient = context.createRadialGradient(
+          blob.x,
+          blob.y,
+          0,
+          blob.x,
+          blob.y,
+          blob.radius
+        );
+        gradient.addColorStop(0, colorToRgba(blob.color, 0.92));
+        gradient.addColorStop(0.45, colorToRgba(blob.color, 0.45));
+        gradient.addColorStop(1, colorToRgba(blob.color, 0));
+        context.fillStyle = gradient;
+        context.beginPath();
+        context.arc(blob.x, blob.y, blob.radius, 0, Math.PI * 2);
+        context.fill();
+      });
+
+      context.globalCompositeOperation = "soft-light";
+      context.fillStyle = "rgba(10, 12, 24, 0.18)";
+      context.fillRect(0, 0, width, height);
+      context.globalCompositeOperation = "source-over";
+    };
+
+    frame = window.requestAnimationFrame(renderFrame);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerdown", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, [
+    colors,
+    resolution,
+    mouseForce,
+    cursorSize,
+    isViscous,
+    viscous,
+    iterationsViscous,
+    iterationsPoisson,
+    isBounce,
+    autoDemo,
+    autoSpeed,
+    autoIntensity,
+    takeoverDuration,
+    autoResumeDelay,
+    autoRampDuration,
+  ]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      role="presentation"
+      aria-hidden="true"
+      className="h-full w-full"
+      style={{ display: "block" }}
+    />
+  );
+};
+
+export default LiquidEther;

--- a/src/components/liquid-ether/LiquidEtherClient.tsx
+++ b/src/components/liquid-ether/LiquidEtherClient.tsx
@@ -1,0 +1,135 @@
+import { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import type { LiquidEtherProps, LiquidEtherSettings } from "@/lib/liquid-ether";
+import { useLiquidEtherSettings } from "@/lib/liquid-ether";
+
+const LiquidEther = lazy(() => import("./LiquidEther"));
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const colorWithAlpha = (color: string, alpha: number) => {
+  const trimmed = color.trim();
+  const hexMatch = trimmed.match(/^#([0-9a-f]{3,8})$/i);
+  if (hexMatch) {
+    const hex = hexMatch[1];
+    const normalized =
+      hex.length === 3
+        ? hex
+            .split("")
+            .map((value) => value + value)
+            .join("")
+        : hex.length >= 6
+        ? hex.slice(0, 6)
+        : hex.padEnd(6, "0");
+    const r = Number.parseInt(normalized.slice(0, 2), 16);
+    const g = Number.parseInt(normalized.slice(2, 4), 16);
+    const b = Number.parseInt(normalized.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${clamp(alpha, 0, 1)})`;
+  }
+
+  const rgbMatch = trimmed.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+  if (rgbMatch) {
+    return `rgba(${rgbMatch[1]}, ${rgbMatch[2]}, ${rgbMatch[3]}, ${clamp(alpha, 0, 1)})`;
+  }
+
+  return trimmed;
+};
+
+const StaticGradient = ({ colors }: { colors: string[] }) => {
+  const [primary, secondary, accent] = useMemo(() => {
+    const palette = colors.length > 0 ? colors : ["#7C3AED", "#0EA5E9", "#EC4899"];
+    return [palette[0], palette[1 % palette.length], palette[2 % palette.length]];
+  }, [colors]);
+
+  const background = useMemo(() => {
+    const primarySoft = colorWithAlpha(primary, 0.65);
+    const secondarySoft = colorWithAlpha(secondary, 0.55);
+    const accentSoft = colorWithAlpha(accent, 0.5);
+    const primaryGlow = colorWithAlpha(primary, 0.28);
+    const secondaryGlow = colorWithAlpha(secondary, 0.25);
+    const accentGlow = colorWithAlpha(accent, 0.22);
+
+    return {
+      backgroundImage: `radial-gradient(circle at 20% 25%, ${primaryGlow} 0%, transparent 55%),` +
+        `radial-gradient(circle at 80% 30%, ${secondaryGlow} 0%, transparent 60%),` +
+        `radial-gradient(circle at 50% 85%, ${accentGlow} 0%, transparent 55%),` +
+        `linear-gradient(135deg, ${primarySoft} 0%, ${secondarySoft} 45%, ${accentSoft} 100%)`,
+    } as const;
+  }, [primary, secondary, accent]);
+
+  return <div className="absolute inset-0" style={background} aria-hidden="true" />;
+};
+
+const checkWebGLSupport = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const canvas = document.createElement("canvas");
+    return Boolean(
+      canvas.getContext("webgl2") ||
+        canvas.getContext("webgl") ||
+        canvas.getContext("experimental-webgl")
+    );
+  } catch {
+    return false;
+  }
+};
+
+const AnimatedLiquidEther = ({ enabled: _enabled, ...settings }: LiquidEtherSettings) => (
+  <Suspense fallback={<StaticGradient colors={settings.colors} />}>
+    <LiquidEther {...(settings as LiquidEtherProps)} />
+  </Suspense>
+);
+
+export const LiquidEtherClient = () => {
+  const settings = useLiquidEtherSettings();
+  const [isMounted, setIsMounted] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [webglAvailable, setWebglAvailable] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updateMotionPreference = () => {
+      setPrefersReducedMotion(mediaQuery.matches);
+    };
+
+    updateMotionPreference();
+    mediaQuery.addEventListener("change", updateMotionPreference);
+    setWebglAvailable(checkWebGLSupport());
+
+    return () => {
+      mediaQuery.removeEventListener("change", updateMotionPreference);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isMounted) return;
+    setWebglAvailable(checkWebGLSupport());
+  }, [isMounted]);
+
+  const shouldAnimate =
+    settings.enabled && isMounted && !prefersReducedMotion && webglAvailable;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"
+    >
+      {shouldAnimate ? (
+        <AnimatedLiquidEther {...settings} />
+      ) : settings.enabled ? (
+        <StaticGradient colors={settings.colors} />
+      ) : (
+        <StaticGradient colors={settings.colors} />
+      )}
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_20%,rgba(8,10,24,0.45),transparent_60%)]" />
+    </div>
+  );
+};

--- a/src/lib/liquid-ether.ts
+++ b/src/lib/liquid-ether.ts
@@ -1,0 +1,157 @@
+import { useMemo } from "react";
+
+export const defaultLiquidEtherColors = [
+  "#7C3AED",
+  "#0EA5E9",
+  "#EC4899",
+] as const;
+
+const ENABLE_KEYS = [
+  "NEXT_PUBLIC_LIQUIDETHER_ENABLED",
+  "VITE_LIQUIDETHER_ENABLED",
+] as const;
+
+const COLORS_KEYS = [
+  "NEXT_PUBLIC_LIQUIDETHER_COLORS",
+  "VITE_LIQUIDETHER_COLORS",
+] as const;
+
+const RESOLUTION_KEYS = [
+  "NEXT_PUBLIC_LIQUIDETHER_RESOLUTION",
+  "VITE_LIQUIDETHER_RESOLUTION",
+] as const;
+
+const INTENSITY_KEYS = [
+  "NEXT_PUBLIC_LIQUIDETHER_INTENSITY",
+  "VITE_LIQUIDETHER_INTENSITY",
+] as const;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const parseBoolean = (rawValue: string | boolean | undefined, fallback: boolean) => {
+  if (typeof rawValue === "boolean") {
+    return rawValue;
+  }
+
+  if (typeof rawValue === "string") {
+    const normalized = rawValue.trim().toLowerCase();
+    if (["1", "true", "on", "yes"].includes(normalized)) {
+      return true;
+    }
+    if (["0", "false", "off", "no"].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return fallback;
+};
+
+const parseNumber = (
+  rawValue: string | boolean | undefined,
+  fallback: number,
+  { min, max }: { min?: number; max?: number } = {}
+) => {
+  if (typeof rawValue === "string" && rawValue.trim() !== "") {
+    const parsed = Number(rawValue);
+    if (Number.isFinite(parsed)) {
+      if (typeof min === "number" && parsed < min) {
+        return min;
+      }
+      if (typeof max === "number" && parsed > max) {
+        return max;
+      }
+      return parsed;
+    }
+  }
+
+  if (typeof rawValue === "boolean") {
+    return rawValue ? 1 : 0;
+  }
+
+  return fallback;
+};
+
+const parseColors = (rawValue: string | boolean | undefined) => {
+  if (typeof rawValue === "string") {
+    const values = rawValue
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+
+    if (values.length > 0) {
+      return values;
+    }
+  }
+
+  return [...defaultLiquidEtherColors];
+};
+
+const pickEnvValue = (keys: readonly string[]) => {
+  const env = import.meta.env as Record<string, string | boolean | undefined>;
+  for (const key of keys) {
+    const value = env?.[key];
+    if (value !== undefined && value !== "") {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+export interface LiquidEtherProps {
+  colors: string[];
+  resolution: number;
+  mouseForce: number;
+  cursorSize: number;
+  isViscous: boolean;
+  viscous: number;
+  iterationsViscous: number;
+  iterationsPoisson: number;
+  isBounce: boolean;
+  autoDemo: boolean;
+  autoSpeed: number;
+  autoIntensity: number;
+  takeoverDuration: number;
+  autoResumeDelay: number;
+  autoRampDuration: number;
+}
+
+export interface LiquidEtherSettings extends LiquidEtherProps {
+  enabled: boolean;
+}
+
+export const getLiquidEtherSettings = (): LiquidEtherSettings => {
+  const enabled = parseBoolean(pickEnvValue(ENABLE_KEYS), true);
+  const colors = parseColors(pickEnvValue(COLORS_KEYS));
+  const resolution = clamp(
+    parseNumber(pickEnvValue(RESOLUTION_KEYS), 0.5, { min: 0.1, max: 1 }),
+    0.3,
+    0.6
+  );
+  const autoIntensity = parseNumber(pickEnvValue(INTENSITY_KEYS), 2.2, {
+    min: 0.5,
+    max: 6,
+  });
+
+  return {
+    enabled,
+    colors,
+    resolution,
+    autoIntensity,
+    mouseForce: 20,
+    cursorSize: 100,
+    isViscous: false,
+    viscous: 30,
+    iterationsViscous: 32,
+    iterationsPoisson: 32,
+    isBounce: false,
+    autoDemo: true,
+    autoSpeed: 0.5,
+    takeoverDuration: 0.25,
+    autoResumeDelay: 3000,
+    autoRampDuration: 0.6,
+  };
+};
+
+export const useLiquidEtherSettings = () =>
+  useMemo(() => getLiquidEtherSettings(), []);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,15 +7,17 @@ import { Footer } from "@/components/Footer";
 
 const Index = () => {
   return (
-    <div className="min-h-screen bg-background">
-      <Header />
-      <main>
-        <HeroSection />
-        <WhatIsSection />
-        <EcosystemSection />
-        <InfrastructureSection />
-      </main>
-      <Footer />
+    <div className="relative min-h-screen text-foreground">
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <Header />
+        <main className="flex-1">
+          <HeroSection />
+          <WhatIsSection />
+          <EcosystemSection />
+          <InfrastructureSection />
+        </main>
+        <Footer />
+      </div>
     </div>
   );
 };

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -12,11 +12,16 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden text-foreground">
+      <div className="relative z-10 rounded-2xl border border-white/10 bg-background/70 px-8 py-10 text-center shadow-[0_30px_60px_rgba(12,14,30,0.45)] backdrop-blur-lg">
+        <h1 className="text-5xl font-bold mb-4 tracking-tight">404</h1>
+        <p className="mb-6 text-lg text-muted-foreground">
+          Oops! Page not found
+        </p>
+        <a
+          href="/"
+          className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/20 px-6 py-2 text-sm font-semibold text-primary-foreground transition hover:border-primary hover:bg-primary/30"
+        >
           Return to Home
         </a>
       </div>


### PR DESCRIPTION
## Summary
- add a Liquid Ether canvas animation with brand colors, env overrides and accessibility fallbacks
- render the client-only background once in the root layout and keep static gradient when animation is disabled
- adjust header and page wrappers so the fluid effect sits behind readable content

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98b27d014832283af8ea69d65de0d