### PR TITLE
Reduce liquid glass intensity and soften whites

### DIFF
--- a/src/components/liquid-ether/LiquidEther.tsx
+++ b/src/components/liquid-ether/LiquidEther.tsx
@@ -105,7 +105,7 @@ const createBlobs = (
       radius: baseRadius,
       color,
       offset: Math.random() * Math.PI * 2,
-      noise: 0.5 + Math.random() * 0.6 * autoIntensity,
+      noise: 0.35 + Math.random() * 0.4 * autoIntensity,
     };
   });
 };
@@ -307,7 +307,7 @@ const LiquidEther = ({
 
       context.setTransform(scale, 0, 0, scale, 0, 0);
       context.globalCompositeOperation = "source-over";
-      context.fillStyle = "rgba(6, 9, 20, 0.22)";
+      context.fillStyle = "rgba(6, 9, 20, 0.32)";
       context.fillRect(0, 0, width, height);
 
       context.globalCompositeOperation = "lighter";
@@ -320,8 +320,8 @@ const LiquidEther = ({
           blob.y,
           blob.radius
         );
-        gradient.addColorStop(0, colorToRgba(blob.color, 0.92));
-        gradient.addColorStop(0.45, colorToRgba(blob.color, 0.45));
+        gradient.addColorStop(0, colorToRgba(blob.color, 0.82));
+        gradient.addColorStop(0.45, colorToRgba(blob.color, 0.32));
         gradient.addColorStop(1, colorToRgba(blob.color, 0));
         context.fillStyle = gradient;
         context.beginPath();
@@ -330,7 +330,7 @@ const LiquidEther = ({
       });
 
       context.globalCompositeOperation = "soft-light";
-      context.fillStyle = "rgba(10, 12, 24, 0.18)";
+      context.fillStyle = "rgba(8, 10, 22, 0.26)";
       context.fillRect(0, 0, width, height);
       context.globalCompositeOperation = "source-over";
     };

--- a/src/components/liquid-ether/LiquidEtherClient.tsx
+++ b/src/components/liquid-ether/LiquidEtherClient.tsx
@@ -42,12 +42,12 @@ const StaticGradient = ({ colors }: { colors: string[] }) => {
   }, [colors]);
 
   const background = useMemo(() => {
-    const primarySoft = colorWithAlpha(primary, 0.65);
-    const secondarySoft = colorWithAlpha(secondary, 0.55);
-    const accentSoft = colorWithAlpha(accent, 0.5);
-    const primaryGlow = colorWithAlpha(primary, 0.28);
-    const secondaryGlow = colorWithAlpha(secondary, 0.25);
-    const accentGlow = colorWithAlpha(accent, 0.22);
+    const primarySoft = colorWithAlpha(primary, 0.5);
+    const secondarySoft = colorWithAlpha(secondary, 0.42);
+    const accentSoft = colorWithAlpha(accent, 0.38);
+    const primaryGlow = colorWithAlpha(primary, 0.2);
+    const secondaryGlow = colorWithAlpha(secondary, 0.18);
+    const accentGlow = colorWithAlpha(accent, 0.16);
 
     return {
       backgroundImage: `radial-gradient(circle at 20% 25%, ${primaryGlow} 0%, transparent 55%),` +
@@ -129,7 +129,7 @@ export const LiquidEtherClient = () => {
       ) : (
         <StaticGradient colors={settings.colors} />
       )}
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_20%,rgba(8,10,24,0.45),transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_20%,rgba(6,8,20,0.55),transparent_60%)]" />
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -10,11 +10,11 @@ All colors MUST be HSL.
   :root {
     /* Base Colors - Deep Space */
     --background: 220 25% 3%;
-    --foreground: 220 10% 98%;
+    --foreground: 220 10% 94%;
 
     /* Glass & Cards - Holographic */
     --card: 220 20% 8%;
-    --card-foreground: 220 10% 95%;
+    --card-foreground: 220 10% 90%;
     --glass: 220 25% 12%;
 
     /* Popover */
@@ -23,13 +23,13 @@ All colors MUST be HSL.
 
     /* Brand Colors - Neon Cyber */
     --primary: 280 95% 70%;
-    --primary-foreground: 220 10% 98%;
+    --primary-foreground: 220 10% 94%;
     --primary-glow: 290 100% 80%;
     --primary-dark: 280 85% 45%;
 
     /* Secondary - Cyber Pink */
     --secondary: 320 90% 65%;
-    --secondary-foreground: 220 10% 98%;
+    --secondary-foreground: 220 10% 94%;
     --secondary-glow: 330 100% 75%;
 
     /* Muted - Deep Purple */
@@ -48,7 +48,7 @@ All colors MUST be HSL.
 
     /* Destructive */
     --destructive: 0 85% 65%;
-    --destructive-foreground: 220 10% 98%;
+    --destructive-foreground: 220 10% 94%;
 
     /* Borders & Inputs */
     --border: 260 40% 25%;
@@ -93,7 +93,7 @@ All colors MUST be HSL.
     --sidebar-background: 220 15% 8%;
     --sidebar-foreground: 220 10% 85%;
     --sidebar-primary: 260 85% 65%;
-    --sidebar-primary-foreground: 220 10% 98%;
+    --sidebar-primary-foreground: 220 10% 94%;
     --sidebar-accent: 220 15% 15%;
     --sidebar-accent-foreground: 220 10% 85%;
     --sidebar-border: 220 15% 20%;

--- a/src/lib/liquid-ether.ts
+++ b/src/lib/liquid-ether.ts
@@ -128,7 +128,7 @@ export const getLiquidEtherSettings = (): LiquidEtherSettings => {
     0.3,
     0.6
   );
-  const autoIntensity = parseNumber(pickEnvValue(INTENSITY_KEYS), 2.2, {
+  const autoIntensity = parseNumber(pickEnvValue(INTENSITY_KEYS), 1.4, {
     min: 0.5,
     max: 6,
   });


### PR DESCRIPTION
## Summary
- lower the default Liquid Ether intensity and tone down blob animation noise
- darken the Liquid Ether rendering and static gradient overlays to soften the liquid glass glow
- slightly darken neutral foreground tokens to reduce the harshness of white UI text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c99bb2b4488322adce2ac1fce134e1