### PR TITLE
Suaviza efeito Liquid Ether e tons claros

### DIFF
--- a/src/components/liquid-ether/LiquidEtherClient.tsx
+++ b/src/components/liquid-ether/LiquidEtherClient.tsx
@@ -42,12 +42,12 @@ const StaticGradient = ({ colors }: { colors: string[] }) => {
   }, [colors]);
 
   const background = useMemo(() => {
-    const primarySoft = colorWithAlpha(primary, 0.65);
-    const secondarySoft = colorWithAlpha(secondary, 0.55);
-    const accentSoft = colorWithAlpha(accent, 0.5);
-    const primaryGlow = colorWithAlpha(primary, 0.28);
-    const secondaryGlow = colorWithAlpha(secondary, 0.25);
-    const accentGlow = colorWithAlpha(accent, 0.22);
+    const primarySoft = colorWithAlpha(primary, 0.55);
+    const secondarySoft = colorWithAlpha(secondary, 0.45);
+    const accentSoft = colorWithAlpha(accent, 0.4);
+    const primaryGlow = colorWithAlpha(primary, 0.22);
+    const secondaryGlow = colorWithAlpha(secondary, 0.2);
+    const accentGlow = colorWithAlpha(accent, 0.18);
 
     return {
       backgroundImage: `radial-gradient(circle at 20% 25%, ${primaryGlow} 0%, transparent 55%),` +

--- a/src/index.css
+++ b/src/index.css
@@ -10,26 +10,26 @@ All colors MUST be HSL.
   :root {
     /* Base Colors - Deep Space */
     --background: 220 25% 3%;
-    --foreground: 220 10% 98%;
+    --foreground: 220 12% 94%;
 
     /* Glass & Cards - Holographic */
     --card: 220 20% 8%;
-    --card-foreground: 220 10% 95%;
+    --card-foreground: 220 12% 92%;
     --glass: 220 25% 12%;
 
     /* Popover */
     --popover: 220 20% 6%;
-    --popover-foreground: 220 10% 98%;
+    --popover-foreground: 220 12% 94%;
 
     /* Brand Colors - Neon Cyber */
     --primary: 280 95% 70%;
-    --primary-foreground: 220 10% 98%;
+    --primary-foreground: 220 12% 94%;
     --primary-glow: 290 100% 80%;
     --primary-dark: 280 85% 45%;
 
     /* Secondary - Cyber Pink */
     --secondary: 320 90% 65%;
-    --secondary-foreground: 220 10% 98%;
+    --secondary-foreground: 220 12% 94%;
     --secondary-glow: 330 100% 75%;
 
     /* Muted - Deep Purple */
@@ -48,7 +48,7 @@ All colors MUST be HSL.
 
     /* Destructive */
     --destructive: 0 85% 65%;
-    --destructive-foreground: 220 10% 98%;
+    --destructive-foreground: 220 12% 94%;
 
     /* Borders & Inputs */
     --border: 260 40% 25%;

--- a/src/lib/liquid-ether.ts
+++ b/src/lib/liquid-ether.ts
@@ -128,7 +128,7 @@ export const getLiquidEtherSettings = (): LiquidEtherSettings => {
     0.3,
     0.6
   );
-  const autoIntensity = parseNumber(pickEnvValue(INTENSITY_KEYS), 2.2, {
+  const autoIntensity = parseNumber(pickEnvValue(INTENSITY_KEYS), 1.3, {
     min: 0.5,
     max: 6,
   });


### PR DESCRIPTION
## Summary
- reduz a intensidade do Liquid Ether normalizando o parâmetro de animação e suavizando os gradientes do shader
- ajusta o gradiente estático para acompanhar o efeito menos intenso
- escurece ligeiramente os tons claros globais para diminuir o brilho geral

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c99bb2b4488322adce2ac1fce134e1