### PR TITLE
Tone down liquid glass intensity

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ export const Header = () => {
       transition={{ duration: 0.6, ease: "easeOut" }}
       className="fixed top-0 left-0 right-0 z-40 p-4"
     >
-      <div className="max-w-6xl mx-auto flex items-center justify-between rounded-2xl border border-white/10 bg-background/70 px-5 py-3 shadow-[0_20px_45px_rgba(16,18,35,0.35)] backdrop-blur-md">
+      <div className="max-w-6xl mx-auto flex items-center justify-between glass rounded-2xl px-5 py-3">
         <motion.div
           initial={{ x: -30, opacity: 0 }}
           animate={{ x: 0, opacity: 1 }}

--- a/src/index.css
+++ b/src/index.css
@@ -10,26 +10,26 @@ All colors MUST be HSL.
   :root {
     /* Base Colors - Deep Space */
     --background: 220 25% 3%;
-    --foreground: 220 10% 98%;
+    --foreground: 220 12% 92%;
 
     /* Glass & Cards - Holographic */
     --card: 220 20% 8%;
-    --card-foreground: 220 10% 95%;
+    --card-foreground: 220 12% 90%;
     --glass: 220 25% 12%;
 
     /* Popover */
     --popover: 220 20% 6%;
-    --popover-foreground: 220 10% 98%;
+    --popover-foreground: 220 12% 92%;
 
     /* Brand Colors - Neon Cyber */
     --primary: 280 95% 70%;
-    --primary-foreground: 220 10% 98%;
+    --primary-foreground: 220 12% 92%;
     --primary-glow: 290 100% 80%;
     --primary-dark: 280 85% 45%;
 
     /* Secondary - Cyber Pink */
     --secondary: 320 90% 65%;
-    --secondary-foreground: 220 10% 98%;
+    --secondary-foreground: 220 12% 92%;
     --secondary-glow: 330 100% 75%;
 
     /* Muted - Deep Purple */
@@ -48,7 +48,7 @@ All colors MUST be HSL.
 
     /* Destructive */
     --destructive: 0 85% 65%;
-    --destructive-foreground: 220 10% 98%;
+    --destructive-foreground: 220 12% 92%;
 
     /* Borders & Inputs */
     --border: 260 40% 25%;
@@ -61,7 +61,7 @@ All colors MUST be HSL.
     /* Advanced Gradients */
     --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-glow)), hsl(var(--secondary)));
     --gradient-hero: radial-gradient(ellipse at center, hsl(var(--primary) / 0.4), hsl(var(--secondary) / 0.3), hsl(var(--accent) / 0.2), transparent);
-    --gradient-glass: linear-gradient(135deg, hsl(var(--glass) / 0.9), hsl(var(--primary) / 0.1), hsl(var(--glass) / 0.5));
+    --gradient-glass: linear-gradient(135deg, hsl(var(--glass) / 0.8), hsl(var(--primary) / 0.06), hsl(var(--glass) / 0.35));
     --gradient-cyber: linear-gradient(45deg, hsl(var(--primary)), hsl(var(--accent)), hsl(var(--tertiary)), hsl(var(--secondary)));
     --gradient-hologram: linear-gradient(90deg, 
       hsl(var(--primary) / 0.8) 0%, 
@@ -72,10 +72,10 @@ All colors MUST be HSL.
     
     /* Advanced Shadows & Effects */
     --shadow-glow: 0 0 80px hsl(var(--primary) / 0.5), 0 0 120px hsl(var(--accent) / 0.3);
-    --shadow-glass: 0 8px 32px hsl(220 20% 0% / 0.4), inset 0 1px 0 hsl(var(--primary) / 0.1);
+    --shadow-glass: 0 6px 24px hsl(220 35% 2% / 0.28), inset 0 1px 0 hsl(var(--foreground) / 0.05);
     --shadow-cyber: 0 0 20px hsl(var(--primary) / 0.8), 0 0 40px hsl(var(--accent) / 0.6), 0 0 80px hsl(var(--secondary) / 0.4);
     --shadow-hologram: 0 0 30px hsl(var(--tertiary) / 0.7), inset 0 1px 1px hsl(var(--primary) / 0.3);
-    --backdrop-blur: blur(20px);
+    --backdrop-blur: blur(14px);
     --backdrop-blur-heavy: blur(40px);
 
     /* 3D Transforms */
@@ -134,7 +134,7 @@ All colors MUST be HSL.
 @layer components {
   /* Advanced Glass Morphism */
   .glass {
-    @apply bg-glass/90 backdrop-blur-xl border border-primary/20;
+    @apply bg-glass/75 backdrop-blur-lg border border-primary/10;
     box-shadow: var(--shadow-glass);
   }
 
@@ -153,7 +153,7 @@ All colors MUST be HSL.
     right: 0;
     height: 1px;
     background: var(--gradient-hologram);
-    opacity: 0.6;
+    opacity: 0.4;
   }
 
   /* Holographic Effects */


### PR DESCRIPTION
## Summary
- soften the glass morphism palette by darkening foreground neutrals, easing gradients and shadows, and reducing blur strength
- reuse the shared glass utility for the header so its styling follows the lower-intensity treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c99bb2b4488322adce2ac1fce134e1