### PR TITLE
Centralize link configuration and adjust liquid effect

### DIFF
--- a/src/components/AdminLogin.tsx
+++ b/src/components/AdminLogin.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Lock } from "lucide-react";
 import { useLanguage } from "@/hooks/useLanguage";
+import { LINKS } from "@/config/links";
 import { motion } from "framer-motion";
 
 export const AdminLogin = () => {
@@ -19,7 +20,7 @@ export const AdminLogin = () => {
         asChild
       >
         <a
-          href="https://it.monynha.online"
+          href={LINKS.admin.itPortal}
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Admin Login"

--- a/src/components/EcosystemSection.tsx
+++ b/src/components/EcosystemSection.tsx
@@ -1,32 +1,33 @@
 import { useLanguage } from "@/hooks/useLanguage";
+import { LINKS } from "@/config/links";
 import { motion } from "framer-motion";
 import { ExternalLink, Globe, Code, Users, User } from "lucide-react";
 import { HolographicCard } from "./HolographicCard";
 
 const ecosystemSites = [
   {
-    domain: "monynha.com",
+    ...LINKS.ecosystem.monynhaCom,
     icon: Globe,
     descKey: 'monynhaComDesc' as const,
     color: "text-primary",
     bgColor: "bg-primary/10"
   },
   {
-    domain: "monynha.tech",
+    ...LINKS.ecosystem.monynhaTech,
     icon: Code,
     descKey: 'monynahTechDesc' as const,
     color: "text-accent",
     bgColor: "bg-accent/10"
   },
   {
-    domain: "monynha.fun",
+    ...LINKS.ecosystem.monynhaFun,
     icon: Users,
     descKey: 'monynhaFunDesc' as const,
     color: "text-primary-glow",
     bgColor: "bg-primary-glow/10"
   },
   {
-    domain: "monynha.me",
+    ...LINKS.ecosystem.monynhaMe,
     icon: User,
     descKey: 'monynhaMeDesc' as const,
     color: "text-emerald-400",
@@ -65,7 +66,7 @@ export const EcosystemSection = () => {
           {ecosystemSites.map((site, index) => (
             <motion.a
               key={site.domain}
-              href={`https://${site.domain}`}
+              href={site.url}
               target="_blank"
               rel="noopener noreferrer"
               className="group cursor-pointer"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { useLanguage } from "@/hooks/useLanguage";
+import { LINKS } from "@/config/links";
 import { motion } from "framer-motion";
 import { Heart, Github, Twitter, Globe } from "lucide-react";
 
@@ -49,7 +50,7 @@ export const Footer = () => {
             </p>
             <div className="flex items-center gap-4">
               <motion.a
-                href="https://github.com/monynha"
+                href={LINKS.social.github}
                 target="_blank"
                 rel="noopener noreferrer"
                 whileHover={{ scale: 1.1 }}
@@ -59,7 +60,7 @@ export const Footer = () => {
                 <Github className="h-4 w-4" />
               </motion.a>
               <motion.a
-                href="https://twitter.com/monynha"
+                href={LINKS.social.twitter}
                 target="_blank"
                 rel="noopener noreferrer"
                 whileHover={{ scale: 1.1 }}
@@ -69,7 +70,7 @@ export const Footer = () => {
                 <Twitter className="h-4 w-4" />
               </motion.a>
               <motion.a
-                href="https://monynha.com"
+                href={LINKS.social.website}
                 target="_blank"
                 rel="noopener noreferrer"
                 whileHover={{ scale: 1.1 }}
@@ -97,7 +98,7 @@ export const Footer = () => {
                 {t('ecosystem')}
               </button>
               <a
-                href="https://monynha.com/about"
+                href={LINKS.social.about}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block text-muted-foreground hover:text-primary transition-colors"
@@ -105,7 +106,7 @@ export const Footer = () => {
                 {t('about')}
               </a>
               <a
-                href="https://monynha.com/contact"
+                href={LINKS.social.contact}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block text-muted-foreground hover:text-primary transition-colors"
@@ -124,7 +125,7 @@ export const Footer = () => {
           >
             <h4 className="font-semibold mb-4 text-foreground">Admin</h4>
             <a
-              href="https://admin.monynha.online"
+              href={LINKS.admin.dashboard}
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-primary transition-colors"

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight, Sparkles, Zap } from "lucide-react";
 import { useLanguage } from "@/hooks/useLanguage";
+import { LINKS } from "@/config/links";
 import { motion } from "framer-motion";
 import { CyberGrid } from "./CyberGrid";
 import { CyberButton } from "./CyberButton";
@@ -177,7 +178,7 @@ export const HeroSection = () => {
           <CyberButton
             variant="ghost"
             size="lg"
-            href="https://admin.monynha.online"
+            href={LINKS.admin.dashboard}
             target="_blank"
             rel="noopener noreferrer"
             className="text-lg"

--- a/src/components/liquid-ether/LiquidEther.tsx
+++ b/src/components/liquid-ether/LiquidEther.tsx
@@ -94,7 +94,7 @@ const createBlobs = (
   return Array.from({ length: count }, (_, index): BlobState => {
     const color = colors[index % colors.length];
     const baseRadius =
-      maxDimension * (0.24 + (index % colors.length) * 0.015 + Math.random() * 0.08);
+      maxDimension * (0.16 + (index % colors.length) * 0.01 + Math.random() * 0.05);
 
     return {
       x: Math.random() * width,

--- a/src/config/links.ts
+++ b/src/config/links.ts
@@ -1,0 +1,35 @@
+export const LINKS = {
+  home: "/",
+  social: {
+    github: "https://github.com/monynha",
+    twitter: "https://twitter.com/monynha",
+    website: "https://monynha.com",
+    about: "https://monynha.com/about",
+    contact: "https://monynha.com/contact",
+  },
+  admin: {
+    dashboard: "https://admin.monynha.online",
+    itPortal: "https://it.monynha.online",
+  },
+  ecosystem: {
+    monynhaCom: {
+      domain: "monynha.com",
+      url: "https://monynha.com",
+    },
+    monynhaTech: {
+      domain: "monynha.tech",
+      url: "https://monynha.tech",
+    },
+    monynhaFun: {
+      domain: "monynha.fun",
+      url: "https://monynha.fun",
+    },
+    monynhaMe: {
+      domain: "monynha.me",
+      url: "https://monynha.me",
+    },
+  },
+} as const;
+
+export type LinkConfig = typeof LINKS;
+export type EcosystemLinkKey = keyof LinkConfig["ecosystem"];

--- a/src/lib/liquid-ether.ts
+++ b/src/lib/liquid-ether.ts
@@ -139,7 +139,7 @@ export const getLiquidEtherSettings = (): LiquidEtherSettings => {
     resolution,
     autoIntensity,
     mouseForce: 20,
-    cursorSize: 100,
+    cursorSize: 80,
     isViscous: false,
     viscous: 30,
     iterationsViscous: 32,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { LINKS } from "@/config/links";
 
 const NotFound = () => {
   const location = useLocation();
@@ -19,7 +20,7 @@ const NotFound = () => {
           Oops! Page not found
         </p>
         <a
-          href="/"
+          href={LINKS.home}
           className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/20 px-6 py-2 text-sm font-semibold text-primary-foreground transition hover:border-primary hover:bg-primary/30"
         >
           Return to Home


### PR DESCRIPTION
## Summary
- add a dedicated LINKs configuration module and refactor footer, hero, admin login, ecosystem, and 404 views to consume those URLs for easier maintenance
- reduce the liquid glass background presence by shrinking blob radii and cursor influence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a1b3b89083228ec9a7241f464345