### PR TITLE
Adicionar tokens de profundidade e utilitários de elevação

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -132,6 +132,88 @@ All SVG assets use colors that match the CSS custom properties defined in `src/i
 --background: 220 25% 3%;
 ```
 
+## Elevation & Depth System
+
+The UI uses a progressive elevation system to communicate hierarchy and interactivity. The tokens live in `src/index.css` and are mapped to Tailwind utilities in `tailwind.config.ts`.
+
+### Depth Tokens
+
+Depth tokens build on standard shadow sizes for light mode and provide explicit overrides for dark mode.
+
+```css
+:root {
+  --shadow-sm: 0 2px 6px hsl(220 20% 0% / 0.08);
+  --shadow-md: 0 6px 15px -2px hsl(220 20% 0% / 0.12);
+  --shadow-lg: 0 12px 28px -4px hsl(220 20% 0% / 0.18);
+  --shadow-depth-1: var(--shadow-sm);
+  --shadow-depth-2: var(--shadow-md);
+  --shadow-depth-3: var(--shadow-lg);
+}
+
+.dark {
+  --shadow-depth-1: 0 2px 6px rgba(0, 0, 0, 0.2);
+  --shadow-depth-2: 0 6px 15px -2px rgba(0, 0, 0, 0.3);
+  --shadow-depth-3: 0 8px 24px -3px rgba(0, 0, 0, 0.4);
+}
+```
+
+Tailwind exposes these as `shadow-depth-1`, `shadow-depth-2`, and `shadow-depth-3`, so you can use them directly or via the convenience utilities below.
+
+### Global Elevation Utilities
+
+Use the following CSS utilities (defined in `@layer utilities`) to apply consistent depth patterns without modifying component internals.
+
+```css
+.elevation-card {
+  @apply shadow-depth-1 transition-shadow duration-300;
+}
+.elevation-card:hover,
+.elevation-card:focus {
+  @apply shadow-depth-2;
+}
+
+.elevation-hover {
+  @apply shadow-none transition-shadow duration-300;
+}
+.elevation-hover:hover,
+.elevation-hover:focus {
+  @apply shadow-depth-1;
+}
+
+.elevation-dialog {
+  @apply shadow-depth-3;
+}
+
+.elevation-fab {
+  @apply shadow-depth-2 transition-shadow duration-300;
+}
+.elevation-fab:hover,
+.elevation-fab:focus {
+  @apply shadow-depth-3;
+}
+```
+
+### Usage Examples
+
+```tsx
+<div className="elevation-card rounded-lg bg-card p-4">
+  <PlaylistCard data={item} />
+</div>
+
+<button className="elevation-fab rounded-full bg-primary px-4 py-3 text-primary-foreground">
+  ➕
+</button>
+
+<DialogContent className="elevation-dialog">
+  ...
+</DialogContent>
+```
+
+### Accessibility Notes
+
+- When using `.elevation-card` or `.elevation-hover` on focusable elements, consider adding focus rings (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`) so keyboard users get a clear indicator in addition to the shadow.
+- Ensure dialog/popover containers also use the existing z-index utilities (`z-50` or similar) so visual elevation matches stacking order.
+
 ### Border Radius
 
 All assets use rounded corners matching the design system:

--- a/src/index.css
+++ b/src/index.css
@@ -71,6 +71,12 @@ All colors MUST be HSL.
       hsl(var(--primary) / 0.8) 100%);
     
     /* Advanced Shadows & Effects */
+    --shadow-sm: 0 2px 6px hsl(220 20% 0% / 0.08);
+    --shadow-md: 0 6px 15px -2px hsl(220 20% 0% / 0.12);
+    --shadow-lg: 0 12px 28px -4px hsl(220 20% 0% / 0.18);
+    --shadow-depth-1: var(--shadow-sm);
+    --shadow-depth-2: var(--shadow-md);
+    --shadow-depth-3: var(--shadow-lg);
     --shadow-glow: 0 0 80px hsl(var(--primary) / 0.5), 0 0 120px hsl(var(--accent) / 0.3);
     --shadow-glass: 0 8px 32px hsl(220 20% 0% / 0.4), inset 0 1px 0 hsl(var(--primary) / 0.1);
     --shadow-cyber: 0 0 20px hsl(var(--primary) / 0.8), 0 0 40px hsl(var(--accent) / 0.6), 0 0 80px hsl(var(--secondary) / 0.4);
@@ -98,6 +104,12 @@ All colors MUST be HSL.
     --sidebar-accent-foreground: 220 10% 85%;
     --sidebar-border: 220 15% 20%;
     --sidebar-ring: 260 85% 65%;
+  }
+
+  .dark {
+    --shadow-depth-1: 0 2px 6px rgba(0, 0, 0, 0.2);
+    --shadow-depth-2: 0 6px 15px -2px rgba(0, 0, 0, 0.3);
+    --shadow-depth-3: 0 8px 24px -3px rgba(0, 0, 0, 0.4);
   }
 
   .light {
@@ -338,6 +350,36 @@ All colors MUST be HSL.
     25% { background-position: 100% 0%; }
     50% { background-position: 100% 100%; }
     75% { background-position: 0% 100%; }
+  }
+}
+
+@layer utilities {
+  .elevation-card {
+    @apply shadow-depth-1 transition-shadow duration-300;
+  }
+  .elevation-card:hover,
+  .elevation-card:focus {
+    @apply shadow-depth-2;
+  }
+
+  .elevation-hover {
+    @apply shadow-none transition-shadow duration-300;
+  }
+  .elevation-hover:hover,
+  .elevation-hover:focus {
+    @apply shadow-depth-1;
+  }
+
+  .elevation-dialog {
+    @apply shadow-depth-3;
+  }
+
+  .elevation-fab {
+    @apply shadow-depth-2 transition-shadow duration-300;
+  }
+  .elevation-fab:hover,
+  .elevation-fab:focus {
+    @apply shadow-depth-3;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -73,7 +73,10 @@ export default {
 			},
 			boxShadow: {
 				glow: 'var(--shadow-glow)',
-				glass: 'var(--shadow-glass)'
+				glass: 'var(--shadow-glass)',
+				'depth-1': 'var(--shadow-depth-1)',
+				'depth-2': 'var(--shadow-depth-2)',
+				'depth-3': 'var(--shadow-depth-3)'
 			},
 			backdropBlur: {
 				glass: 'var(--backdrop-blur)'


### PR DESCRIPTION
### Motivation

- Padronizar um sistema de elevação (depth / elevation) para comunicar hierarquia e interatividade sem alterar componentes React.
- Expor níveis de sombra como tokens CSS reutilizáveis e como utilitários Tailwind para aplicação global e fácil ajuste por tema (light/dark).

### Description

- Adiciona tokens de sombra em `src/index.css` (`--shadow-sm`, `--shadow-md`, `--shadow-lg`) e mapeia `--shadow-depth-1`, `--shadow-depth-2`, `--shadow-depth-3` para representar níveis graduais de elevação.
- Adiciona overrides em `.dark` para melhorar contraste das sombras em modo escuro.
- Cria utilitários globais em `@layer utilities` em `src/index.css` com classes de conveniência `.elevation-card`, `.elevation-hover`, `.elevation-dialog` e `.elevation-fab` que usam `@apply` para transições e estados `:hover`/`:focus`.
- Expõe os tokens de profundidade no `tailwind.config.ts` estendendo `boxShadow` com `shadow-depth-1`, `shadow-depth-2` e `shadow-depth-3`.
- Documenta o sistema de elevação, exemplos de uso e notas de acessibilidade em `DESIGN.md`.

### Testing

- Nenhum teste automatizado foi executado neste PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e865a724c8322bad4a31f076187f6)